### PR TITLE
Added some convenience methods (which Q uses)

### DIFF
--- a/ayepromise.js
+++ b/ayepromise.js
@@ -184,7 +184,20 @@
                 },
                 isPending: function () {
                     return state === PENDING;
-                }
+                },
+				inspect: function () {
+					var details = {};
+					if (state === PENDING) {
+						details.state = "pending";
+					} else if (state === FULFILLED) {
+						details.state = "fulfilled";
+						details.value = outcome;
+					} else if (state === REJECTED) {
+						details.state = "rejected";
+						details.reason = outcome;
+					}
+					return details;
+				}
             }
         };
     };

--- a/ayepromise.js
+++ b/ayepromise.js
@@ -1,20 +1,22 @@
 // UMD header
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
+    if (typeof define === "function" && define.amd) {
         define(factory);
-    } else if (typeof exports === 'object') {
+    } else if (typeof exports === "object") {
         module.exports = factory();
     } else {
         root.ayepromise = factory();
     }
 }(this, function () {
-    'use strict';
+    "use strict";
 
     var ayepromise = function (value) {
-		if (ayepromise.isPromise(value)) return value;
+		if (ayepromise.isPromise(value)) {
+			return value;
+		}
         var wrapped = ayepromise.defer();
         wrapped.resolve(value);
-        return wrapped;
+        return wrapped.promise;
     };
 
     /* Wrap an arbitrary number of functions and allow only one of them to be
@@ -37,8 +39,8 @@
         // Make sure we only access the accessor once as required by the spec
         var then = obj && obj.then;
 
-        if (typeof obj === 'object' && typeof then === 'function') {
-            // Bind function back to it's object (so fan's of 'this' don't get sad)
+        if (typeof obj === "object" && typeof then === "function") {
+            // Bind function back to it"s object (so fan"s of "this" don"t get sad)
             return function() { return then.apply(obj, arguments); };
         }
     };
@@ -57,7 +59,7 @@
                 }
 
                 if (returnValue === defer.promise) {
-                    defer.reject(new TypeError('Cannot resolve promise with itself'));
+                    defer.reject(new TypeError("Cannot resolve promise with itself"));
                 } else {
                     defer.resolve(returnValue);
                 }
@@ -188,7 +190,7 @@
     };
 
     ayepromise.isPromise = function (promise) {
-        return (promise && typeof promise.then === 'function');
+        return (promise && typeof promise.then === "function");
     };
 
     return ayepromise;

--- a/ayepromise.js
+++ b/ayepromise.js
@@ -10,7 +10,12 @@
 }(this, function () {
     'use strict';
 
-    var ayepromise = {};
+    var ayepromise = function (value) {
+		if (ayepromise.isPromise(value)) return value;
+        var wrapped = ayepromise.defer();
+        wrapped.resolve(value);
+        return wrapped;
+    };
 
     /* Wrap an arbitrary number of functions and allow only one of them to be
        executed and only once */
@@ -32,7 +37,7 @@
         // Make sure we only access the accessor once as required by the spec
         var then = obj && obj.then;
 
-        if (typeof obj === "object" && typeof then === "function") {
+        if (typeof obj === 'object' && typeof then === 'function') {
             // Bind function back to it's object (so fan's of 'this' don't get sad)
             return function() { return then.apply(obj, arguments); };
         }
@@ -168,9 +173,22 @@
                 then: registerThenHandler,
                 fail: function (onRejected) {
                     return registerThenHandler(null, onRejected);
+                },
+                isFulfilled: function () {
+                    return state === FULFILLED;
+                },
+                isRejected: function () {
+                    return state === REJECTED;
+                },
+                isPending: function () {
+                    return state === PENDING;
                 }
             }
         };
+    };
+
+    ayepromise.isPromise = function (promise) {
+        return (promise && typeof promise.then === 'function');
     };
 
     return ayepromise;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ayepromise",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "ayepromise.js",
   "devDependencies": {
     "jasmine": "~1.3.1"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ayepromise",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "ayepromise.js",
   "devDependencies": {
     "jasmine": "~1.3.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "ayepromise",
   "main": "./ayepromise.js",
   "description": "A teeny-tiny promise library",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.1.3",
   "name": "ayepromise",
   "main": "./ayepromise.js",
   "description": "A teeny-tiny promise library",

--- a/test/specs.js
+++ b/test/specs.js
@@ -1,11 +1,11 @@
 (function (definition) {
-    if (typeof module !== 'undefined') {
+    if (typeof module !== "undefined") {
         module.exports = definition;
     } else {
         this.specs = definition;
     }
 })(function (subject, libraryName) {
-    var helpers = this.helpers || require('./helpers.js');
+    var helpers = this.helpers || require("./helpers.js");
 
     describe(libraryName, function () {
 
@@ -22,7 +22,7 @@
 
             it("should not fulfill an already fulfilled promise", function () {
                 var defer = subject.defer(),
-                    onFulfillCallback = jasmine.createSpy('onFulfill'),
+                    onFulfillCallback = jasmine.createSpy("onFulfill"),
                     done = false;
                 defer.promise.then(onFulfillCallback);
                 defer.resolve(null);
@@ -44,10 +44,10 @@
 
             it("should not fulfill a rejected promise", function () {
                 var defer = subject.defer(),
-                    onFulfillCallback = jasmine.createSpy('onFulfill'),
+                    onFulfillCallback = jasmine.createSpy("onFulfill"),
                     done = false;
                 defer.promise.then(onFulfillCallback);
-                defer.reject(new Error('just because'));
+                defer.reject(new Error("just because"));
 
                 setTimeout(function() {
                     defer.resolve(42);
@@ -260,13 +260,13 @@
         describe("reject", function () {
             it("should not reject a fulfilled promise", function () {
                 var defer = subject.defer(),
-                    onRejectCallback = jasmine.createSpy('onReject'),
+                    onRejectCallback = jasmine.createSpy("onReject"),
                     done = false;
                 defer.promise.then(null, onRejectCallback);
                 defer.resolve(null);
 
                 setTimeout(function() {
-                    defer.reject(new Error('because'));
+                    defer.reject(new Error("because"));
 
                     setTimeout(function() {
                         expect(onRejectCallback).not.toHaveBeenCalled();
@@ -281,14 +281,14 @@
 
             it("should not reject a rejected promise", function () {
                 var defer = subject.defer(),
-                    onRejectCallback = jasmine.createSpy('onReject'),
+                    onRejectCallback = jasmine.createSpy("onReject"),
                     done = false;
                 defer.promise.then(null, onRejectCallback);
-                defer.reject(new Error('original reason'));
+                defer.reject(new Error("original reason"));
 
                 setTimeout(function() {
                     onRejectCallback.reset();
-                    defer.reject(new Error('because'));
+                    defer.reject(new Error("because"));
 
                     setTimeout(function() {
                         expect(onRejectCallback).not.toHaveBeenCalled();
@@ -546,6 +546,102 @@
             });
         });
 
+        describe("isFulfilled", function () {
+            it("should return true if the promise is fulfilled", function () {
+                var defer = subject.defer();
+                defer.resolve();
+                var isFulfilled = defer.promise.isFulfilled();
+                expect(isFulfilled).toBe(true);
+            });
+            it("should return false if the promise is pending", function () {
+                var defer = subject.defer();
+                var isFulfilled = defer.promise.isFulfilled();
+                expect(isFulfilled).toBe(false);
+            });
+            it("should return false if the promise is rejected", function () {
+                var defer = subject.defer();
+                defer.reject();
+                var isFulfilled = defer.promise.isFulfilled();
+                expect(isFulfilled).toBe(false);
+            });
+        });
+
+        describe("isRejected", function () {
+            it("should return true if the promise is rejected", function () {
+                var defer = subject.defer();
+                defer.reject();
+                var isRejected = defer.promise.isRejected();
+                expect(isRejected).toBe(true);
+            });
+            it("should return false if the promise is pending", function () {
+                var defer = subject.defer();
+                var isRejected = defer.promise.isRejected();
+                expect(isRejected).toBe(false);
+            });
+            it("should return false if the promise is fulfilled", function () {
+                var defer = subject.defer();
+                defer.resolve();
+                var isRejected = defer.promise.isRejected();
+                expect(isRejected).toBe(false);
+            });
+        });
+
+        describe("isPending", function () {
+            it("should return true if the promise is pending", function () {
+                var defer = subject.defer();
+                var isPending = defer.promise.isPending();
+                expect(isPending).toBe(true);
+            });
+            it("should return false if the promise is fulfilled", function () {
+                var defer = subject.defer();
+                defer.resolve();
+                var isPending = defer.promise.isPending();
+                expect(isPending).toBe(false);
+            });
+            it("should return false if the promise is rejected", function () {
+                var defer = subject.defer();
+                defer.reject();
+                var isPending = defer.promise.isPending();
+                expect(isPending).toBe(false);
+            });
+        });
+
+        describe("isPromise", function () {
+            it("should return true if called on a promise ", function () {
+                var defer = subject.defer();
+                expect(subject.isPromise(defer.promise)).toBe(true);
+            });
+            it("should return false if called on a non-promise", function () {
+                expect(subject.isPromise("Not a promise")).toBe(false);
+            });
+        });
+
+		describe("ayepromise", function () {
+			it("should be a function", function () {
+				var type = typeof subject;
+				expect(type).toBe("function");
+			});
+			it("when called with a promise, should return said promise", function () {
+				var defer = subject.defer();
+				var promise = subject(defer.promise);
+				expect(promise).toBe(defer.promise);
+			});
+			it("when called with a non-promise value, should return a resolved promise wrapping the value", function () {
+				var promise = subject("Wrap me"),
+                    spy = jasmine.createSpy("call me");
+
+                promise.then(spy);
+
+                waitsFor(function () {
+                    return spy.wasCalled;
+                });
+
+                runs(function () {
+                    expect(spy).toHaveBeenCalledWith("Wrap me");
+                });
+			});
+		});
+
         describe("resolve thenables", function () {
             helpers.testFulfilled("should accept a pseudo promise", null, function (promise, done) {
                 promise
@@ -581,7 +677,7 @@
                     });
             });
 
-            helpers.testFulfilledIfNotQ('should access "then" getter only once', libraryName, null, function (promise, done) {
+            helpers.testFulfilledIfNotQ("should access 'then' getter only once", libraryName, null, function (promise, done) {
                 var getterCallCount = 0;
 
                 promise
@@ -603,7 +699,7 @@
                     });
             });
 
-            it('should not resolve twice when waiting for a thenable', function () {
+            it("should not resolve twice when waiting for a thenable", function () {
                 var defer = subject.defer(),
                     fulfillSpy = jasmine.createSpy("fulfill"),
                     fulfill;
@@ -633,10 +729,10 @@
                 });
             });
 
-            it('should not reject promise when waiting for a thenable from fulfilling', function () {
+            it("should not reject promise when waiting for a thenable from fulfilling", function () {
                 var defer = subject.defer(),
-                    fulfillSpy = jasmine.createSpy('fulfill'),
-                    rejectSpy = jasmine.createSpy('reject'),
+                    fulfillSpy = jasmine.createSpy("fulfill"),
+                    rejectSpy = jasmine.createSpy("reject"),
                     fulfill;
 
                 defer.promise.then(fulfillSpy, rejectSpy);
@@ -667,7 +763,7 @@
         });
 
         describe("rogue thenables", function () {
-            it('should not call fulfill more than once', function () {
+            it("should not call fulfill more than once", function () {
                 var defer = subject.defer(),
                     spy = jasmine.createSpy("call me"),
                     p = defer.promise.then(function () {
@@ -692,7 +788,7 @@
                 });
             });
 
-            it('should not call reject more than once', function () {
+            it("should not call reject more than once", function () {
                 var defer = subject.defer(),
                     spy = jasmine.createSpy("call me"),
                     p = defer.promise.then(function () {
@@ -717,7 +813,7 @@
                 });
             });
 
-            it('should not call fulfill and reject together', function () {
+            it("should not call fulfill and reject together", function () {
                 var defer = subject.defer(),
                     fulfillSpy = jasmine.createSpy("fulfill"),
                     rejectSpy = jasmine.createSpy("reject"),
@@ -758,10 +854,10 @@
                 });
             });
 
-            helpers.ifNotQIt('should reject when thenable accessor throws an error', libraryName, function () {
+            helpers.ifNotQIt("should reject when thenable accessor throws an error", libraryName, function () {
                 var defer = subject.defer(),
-                    spy = jasmine.createSpy('call me'),
-                    e = new Error('error');
+                    spy = jasmine.createSpy("call me"),
+                    e = new Error("error");
 
                 defer.resolve();
                 defer.promise
@@ -785,7 +881,7 @@
                 });
             });
 
-            it('should not reject a failing thenable after it fulfilled', function () {
+            it("should not reject a failing thenable after it fulfilled", function () {
                 var defer = subject.defer(),
                     fulfillSpy = jasmine.createSpy("fulfill"),
                     rejectSpy = jasmine.createSpy("reject"),

--- a/test/specs.js
+++ b/test/specs.js
@@ -606,6 +606,37 @@
             });
         });
 
+
+        describe("inspect", function () {
+            describe("should an object which", function () {
+				it("if the promise is pending, should have 'state' set to 'pending'", function () {
+					var defer = subject.defer();
+					var isPending = defer.promise.isPending();
+					expect(isPending).toBe(true);
+					var inspection = defer.promise.inspect();
+					expect(inspection.state).toBe("pending");
+				});
+				it("if the promise is fulfilled, should have 'state' set to 'fulfilled', and 'value' set to the fulfilling value", function () {
+					var defer = subject.defer();
+					defer.resolve("fulfilling value");
+					var isFulfilled = defer.promise.isFulfilled();
+					expect(isFulfilled).toBe(true);
+					var inspection = defer.promise.inspect();
+					expect(inspection.state).toBe("fulfilled");
+					expect(inspection.value).toBe("fulfilling value");
+				});
+				it("if the promise is rejected, should have 'state' set to 'rejected', and 'reason' set to the rejecting value", function () {
+					var defer = subject.defer();
+					defer.reject("rejecting value");
+					var isRejected = defer.promise.isRejected();
+					expect(isRejected).toBe(true);
+					var inspection = defer.promise.inspect();
+					expect(inspection.state).toBe("rejected");
+					expect(inspection.reason).toBe("rejecting value");
+				});
+            });
+        });
+
         describe("isPromise", function () {
             it("should return true if called on a promise ", function () {
                 var defer = subject.defer();


### PR DESCRIPTION
Hello there,

I wanted to replace q.js with a more lightweight alternative in a project I'm working on, so I picked ayapromise.

Unfortunately I needed some functionalities of q that ayepromise did not provide, namely checking the state of a promise. So I added three convenience methods used by q: isFulfilled, isRejected and isPending.

I also turned the ayepromise object into a function that wraps a value in a promise (or returns a promise), and added a method to check whether something is a promise or not: isPromise.

I added unit tests for all of the above.

Feel free to ignore the pull request. As I liked the project and needed those extra features I forked, but I understand if my changes are not in-line with the project philosophy and you prefer not to merge.

Anyway, thanks for the library.
Bye :-)
